### PR TITLE
魚と猫じゃらし、バフデバフマネージャーの実装

### DIFF
--- a/Assets/Aoyama/Prefab/Dorayaki.prefab
+++ b/Assets/Aoyama/Prefab/Dorayaki.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 5207207155990796783}
   m_Layer: 0
   m_Name: Dorayaki
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Geta.prefab
+++ b/Assets/Aoyama/Prefab/Geta.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 5469396239390988374}
   - component: {fileID: 7863772737438849588}
   - component: {fileID: 8355277912079769022}
+  - component: {fileID: 485377604167205893}
   m_Layer: 0
   m_Name: Geta
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -83,3 +84,24 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &485377604167205893
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4863839554688852148}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.49284083, y: 0.24208453, z: 0.5000011}
+  m_Center: {x: 0.06178724, y: 0.045283046, z: 0.018696792}

--- a/Assets/Aoyama/Prefab/Kandume.prefab
+++ b/Assets/Aoyama/Prefab/Kandume.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 1147795739492554708}
   m_Layer: 0
   m_Name: Kandume
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Katsuobushi.prefab
+++ b/Assets/Aoyama/Prefab/Katsuobushi.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4054436670026328265}
   m_Layer: 0
   m_Name: Katsuobushi
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Kingyobati.prefab
+++ b/Assets/Aoyama/Prefab/Kingyobati.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 35142369343799366}
   m_Layer: 0
   m_Name: Kingyobati
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Koban.prefab
+++ b/Assets/Aoyama/Prefab/Koban.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 8048516231273817553}
   - component: {fileID: 6803087059460570752}
   - component: {fileID: 2085136781191737019}
+  - component: {fileID: 4354021687649467414}
   m_Layer: 0
   m_Name: Koban
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -83,3 +84,24 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4354021687649467414
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7085674889194124881}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.33333397, y: 0.016666602, z: 0.50000095}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Aoyama/Prefab/Kyuuri.prefab
+++ b/Assets/Aoyama/Prefab/Kyuuri.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4237283266285976818}
   m_Layer: 0
   m_Name: Kyuuri
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Makimono.prefab
+++ b/Assets/Aoyama/Prefab/Makimono.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7620683234299416527}
   m_Layer: 0
   m_Name: Makimono
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Matatabi.prefab
+++ b/Assets/Aoyama/Prefab/Matatabi.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8875124835625138555}
   m_Layer: 0
   m_Name: Matatabi
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Nekozyarasi.prefab
+++ b/Assets/Aoyama/Prefab/Nekozyarasi.prefab
@@ -11,9 +11,11 @@ GameObject:
   - component: {fileID: 2752753820625251681}
   - component: {fileID: 3369942885309072983}
   - component: {fileID: 3117521141418296409}
+  - component: {fileID: 742738250480784485}
+  - component: {fileID: 7158295664554622451}
   m_Layer: 0
   m_Name: Nekozyarasi
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -28,8 +30,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 381.2404, y: 0.000008821487, z: 66.402504}
-  m_LocalScale: {x: 0.045026004, y: 0.045026004, z: 0.045026004}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 0.059999995, y: 0.059999995, z: 0.059999995}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -85,3 +87,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &742738250480784485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6616550782761649095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d5915b8101ecf848bc92bd4668cbc9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buff_debuff: {fileID: 0}
+--- !u!65 &7158295664554622451
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6616550782761649095}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.2278404, y: 11.104685, z: 1.557378}
+  m_Center: {x: -0.39735338, y: 4.5523424, z: 0.0014826058}

--- a/Assets/Aoyama/Prefab/Nezumi.prefab
+++ b/Assets/Aoyama/Prefab/Nezumi.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 358577585008767833}
   m_Layer: 0
   m_Name: Nezumi
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5731ccf3447728249b8fd257d3c97499, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 0}
+  player: {fileID: 2278115454019496515, guid: 1d3ad98c788cd5b43857e8ad8ed5682c, type: 3}
   speed: 0.03
   moveTime: 2
   stopTime: 1

--- a/Assets/Aoyama/Prefab/Runba.prefab
+++ b/Assets/Aoyama/Prefab/Runba.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 506118854577993996}
   m_Layer: 0
   m_Name: Runba
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Prefab/Sakana.prefab
+++ b/Assets/Aoyama/Prefab/Sakana.prefab
@@ -11,9 +11,11 @@ GameObject:
   - component: {fileID: 8403354285517862213}
   - component: {fileID: 4640772149339751771}
   - component: {fileID: 1567840753623891835}
+  - component: {fileID: -6421418237061375516}
+  - component: {fileID: 1518474763534226013}
   m_Layer: 0
   m_Name: Sakana
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -86,3 +88,39 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &-6421418237061375516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710639215178213230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebdbfc2d4fb531047847f67fd88f4523, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HP3manager: {fileID: 0}
+--- !u!136 &1518474763534226013
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710639215178213230}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.014056476
+  m_Height: 0.145243
+  m_Direction: 1
+  m_Center: {x: -2.3283067e-10, y: 0.017170103, z: -0.00010606785}

--- a/Assets/Aoyama/Prefab/Shinzyu.prefab
+++ b/Assets/Aoyama/Prefab/Shinzyu.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 6736270041137323345}
   - component: {fileID: 1022076590681595721}
   - component: {fileID: 4998963681231904020}
+  - component: {fileID: 3252160545232007709}
   m_Layer: 0
   m_Name: Shinzyu
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -83,3 +84,24 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3252160545232007709
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8988745998474947345}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.8763156, y: 0.3758421, z: 2.6054277}
+  m_Center: {x: -0.008820294, y: -0.02109781, z: -0.023225129}

--- a/Assets/Aoyama/Prefab/Suzu.prefab
+++ b/Assets/Aoyama/Prefab/Suzu.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8356027679531112077}
   m_Layer: 0
   m_Name: Suzu
-  m_TagString: Item
+  m_TagString: item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Aoyama/Scene/Item-Aoyama.unity
+++ b/Assets/Aoyama/Scene/Item-Aoyama.unity
@@ -240,7 +240,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 307163140}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &307163142
 Camera:
   m_ObjectHideFlags: 0
@@ -372,7 +372,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
@@ -443,6 +443,83 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &400864848
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 742738250480784485, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: playerCon
+      value: 
+      objectReference: {fileID: 8145962093308262437}
+    - target: {fileID: 742738250480784485, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: buff_debuff
+      value: 
+      objectReference: {fileID: 1846178142}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.059999995
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.059999995
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.059999995
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000008821487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2752753820625251681, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6616550782761649095, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
+      propertyPath: m_Name
+      value: Nekozyarasi
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2bfabfaba44053b4e93a56da3bbded2d, type: 3}
 --- !u!1 &442194808
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +625,67 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &570380595
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -6421418237061375516, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7710639215178213230, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_Name
+      value: Sakana
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 382.91772
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 66.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8403354285517862213, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e298e3a9506ab346a0daa535148bc62, type: 3}
 --- !u!1001 &642388886
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -594,7 +732,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3183494735833511246, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.26
+      value: 17.9
       objectReference: {fileID: 0}
     - target: {fileID: 3183494735833511246, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
       propertyPath: m_LocalPosition.y
@@ -602,7 +740,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3183494735833511246, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.3
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 3183494735833511246, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
       propertyPath: m_LocalRotation.w
@@ -713,6 +851,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
+--- !u!1001 &697742538
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 381.10867
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.054
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 65.4994
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6736270041137323345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8988745998474947345, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
+      propertyPath: m_Name
+      value: Shinzyu
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 189857534f8698e42ae6c3a08ba12338, type: 3}
 --- !u!1 &756423101
 GameObject:
   m_ObjectHideFlags: 0
@@ -888,6 +1083,166 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &1279545926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4863839554688852148, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_Name
+      value: Geta
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 380.85516
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000423193
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 70.18763
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9835825
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.113362886
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.11238311
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.08416926
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5469396239390988374, guid: 00109c04264190c4190065c108a78924, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 00109c04264190c4190065c108a78924, type: 3}
+--- !u!1001 &1816622134
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7085674889194124881, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_Name
+      value: Koban
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 381.54855
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 68.65338
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048516231273817553, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc31ba81e02576b4192948b601cd774a, type: 3}
+--- !u!1 &1846178141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1846178143}
+  - component: {fileID: 1846178142}
+  m_Layer: 0
+  m_Name: BuffDebuffManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1846178142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1846178141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed120779cee8a234f959198719c7a85b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerCon: {fileID: 8145962093308262437}
+  stopTime: 2
+--- !u!4 &1846178143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1846178141}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.0206695, y: 0.13675869, z: -1.8643843}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1907308196
 GameObject:
   m_ObjectHideFlags: 0
@@ -1008,238 +1363,251 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c28aac9decdf45409058474a383097c, type: 3}
---- !u!23 &668833177741710566
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7141896541614066851}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: -8657442495611329697, guid: 00c8a3581ef64114f84926985d7ca113, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!4 &1032532471685915511
+--- !u!4 &11025683570335562
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7141896541614066851}
+  m_GameObject: {fileID: 6534746945289868042}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5, y: 0, z: 5}
+  m_LocalRotation: {x: 0.12016817, y: 0.5481617, z: 0.8079082, w: -0.17989679}
+  m_LocalPosition: {x: 0.09979262, y: 0.15350716, z: -0.009958568}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8814924875373889612}
+  m_Father: {fileID: 8607218787004243043}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &183903037133630456
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2322392608559403887}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.74845296, y: -0.00000034101637, z: 0.00071641675, w: 0.6631875}
+  m_LocalPosition: {x: 0.0000000024583642, y: 0.15473321, z: -4.656613e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4711842618106318881}
+  m_Father: {fileID: 4307990368051959257}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &454343646476026035
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6224648825763604526}
+  m_Layer: 6
+  m_Name: UpLeg.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &888086788494253768
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6647807635380555708}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.112849094, y: -0.50323594, z: 0.8366304, w: 0.18457599}
+  m_LocalPosition: {x: -0.09979262, y: 0.15350716, z: -0.009958568}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8949230271590860975}
+  m_Father: {fileID: 8607218787004243043}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1297495963529602554
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4553582587284138215}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.75
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &1333413327091532229
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8687233939688078801}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.6964925, y: -2.3624657e-12, z: 0.00000016606289, w: 0.7175641}
+  m_LocalPosition: {x: -0.000000017436829, y: 0.0036063923, z: -0.073135376}
+  m_LocalScale: {x: 1, y: 1.0000254, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7188367493144839497}
+  m_Father: {fileID: 4658574641059729974}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1872827410078174523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7188367493144839497}
+  m_Layer: 6
+  m_Name: Tail.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2170160289069579735
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7373201546310917934}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.040346768, y: -7.633085e-15, z: -2.8445547e-16, w: 0.99918574}
+  m_LocalPosition: {x: 5.3955745e-16, y: 0.21678706, z: 0.0000000037252903}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2257292714694726912}
+  m_Father: {fileID: 8607218787004243043}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2257292714694726912
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3463425213712838489}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7800728, y: -0.19864011, z: -0.30418038, w: 0.50941414}
+  m_LocalPosition: {x: -8.166699e-16, y: 0.04798214, z: 0.05814568}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5943071206077373607}
+  m_Father: {fileID: 2170160289069579735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2297077368054180529
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7298359342184009883}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.09435402, y: 4.180558e-13, z: -0.000000022496843, w: 0.9955387}
+  m_LocalPosition: {x: -5.3290705e-15, y: 0.086733624, z: -0.000000011175868}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8203618216221069278}
+  m_Father: {fileID: 7188367493144839497}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2322392608559403887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 183903037133630456}
+  m_Layer: 6
+  m_Name: Foot.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2628702113225851363
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4553582587284138215}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.454, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 4695811912248111435}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1732366565340228456
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7681962100937170736}
-  m_Mesh: {fileID: -2687643373584554683, guid: c2c6fda18ff57ed459abf06ebbbcbb62, type: 3}
---- !u!23 &5356846212511902717
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8852787756963501815}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 1043613133195877680, guid: 94c6bbb2d2c0bc04f9c040ad21782f7d, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!4 &5429571905572514160
+--- !u!4 &2686152598055294379
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7681962100937170736}
+  m_GameObject: {fileID: 5141076249776533607}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.18009406, y: 0.044970997, z: -0.051410582, w: 0.981275}
+  m_LocalPosition: {x: 0.00000001071021, y: 0.12236148, z: 0}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7271733266709545568}
+  m_Father: {fileID: 6224648825763604526}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2691868551401171317
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7140482572591265090}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5, y: 0, z: 5}
-  m_LocalScale: {x: 0.17383349, y: 0.1739174, z: 0.1739174}
+  m_LocalPosition: {x: 0.000000012107194, y: 0.000000059604645, z: -0.000000014901161}
+  m_LocalScale: {x: 0.428553, y: 0.428553, z: 0.428553}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 4695811912248111435}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &6015223552912369973
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7681962100937170736}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: -1602390835150884111, guid: c2c6fda18ff57ed459abf06ebbbcbb62, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &6090278905903852663
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8852787756963501815}
-  m_Mesh: {fileID: -5529271311795827417, guid: 94c6bbb2d2c0bc04f9c040ad21782f7d, type: 3}
---- !u!33 &6296432114751251365
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7141896541614066851}
-  m_Mesh: {fileID: -5499625644375129320, guid: 00c8a3581ef64114f84926985d7ca113, type: 3}
---- !u!1 &7141896541614066851
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1032532471685915511}
-  - component: {fileID: 6296432114751251365}
-  - component: {fileID: 668833177741710566}
-  m_Layer: 0
-  m_Name: Kandume
-  m_TagString: Item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7681962100937170736
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5429571905572514160}
-  - component: {fileID: 1732366565340228456}
-  - component: {fileID: 6015223552912369973}
-  m_Layer: 0
-  m_Name: Shinzyu
-  m_TagString: Item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8233579744030125589
+--- !u!4 &2789014193716960744
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8852787756963501815}
+  m_GameObject: {fileID: 4256404115366573355}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.113362886, y: 0.11238311, z: 0.08416926, w: 0.9835825}
-  m_LocalPosition: {x: 5, y: 0, z: 5}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.2082038, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 8814924875373889612}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8852787756963501815
+--- !u!1 &3255972873161196318
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1247,16 +1615,995 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8233579744030125589}
-  - component: {fileID: 6090278905903852663}
-  - component: {fileID: 5356846212511902717}
-  m_Layer: 0
-  m_Name: Geta
-  m_TagString: Item
+  - component: {fileID: 8203618216221069278}
+  m_Layer: 6
+  m_Name: Tail.003_end
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!136 &3352834383585050582
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Height: 5
+  m_Direction: 0
+  m_Center: {x: 0, y: 0, z: 3.3}
+--- !u!1 &3463425213712838489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2257292714694726912}
+  m_Layer: 6
+  m_Name: Mouth
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3747044170552412223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1c8118ce66d9ce4d91a5346cf2639e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3913231710814042125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5943071206077373607}
+  m_Layer: 6
+  m_Name: Mouth_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &3953409550894745338
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4583912175739985978}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 1
+--- !u!65 &4180355613093911740
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.8, y: 1, z: 9.113945}
+  m_Center: {x: 0, y: 0, z: 5.4369726}
+--- !u!1 &4256404115366573355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2789014193716960744}
+  m_Layer: 6
+  m_Name: Arm.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4294399433618179486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4658574641059729974}
+  m_Layer: 6
+  m_Name: Spine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4307990368051959257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8401638981111238710}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.2628662, y: -0.06389546, z: 0.04816459, w: 0.9615087}
+  m_LocalPosition: {x: -0.0000000055879354, y: 0.122361526, z: 0.000000015832484}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 183903037133630456}
+  m_Father: {fileID: 8289972788491150895}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &4308960723045311337
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 1.5719783
+  m_Direction: 0
+  m_Center: {x: 0, y: 0, z: 1}
+--- !u!1 &4553582587284138215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2628702113225851363}
+  - component: {fileID: 1297495963529602554}
+  - component: {fileID: 8024219688827246704}
+  m_Layer: 0
+  m_Name: GetItemArea
+  m_TagString: GetItemArea
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4583912175739985978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4695811912248111435}
+  - component: {fileID: 8910344399797964928}
+  - component: {fileID: 8145962093308262437}
+  - component: {fileID: 3953409550894745338}
+  - component: {fileID: 6947911646296722071}
+  m_Layer: 6
+  m_Name: Player (1)
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4658574641059729974
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4294399433618179486}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071067, y: -0.00000008429368, z: -0.00000008429368, w: 0.7071068}
+  m_LocalPosition: {x: -0.0000000121071935, y: 0.039165534, z: 0.26277256}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8607218787004243043}
+  - {fileID: 1333413327091532229}
+  - {fileID: 8289972788491150895}
+  - {fileID: 6224648825763604526}
+  m_Father: {fileID: 7446305213577957298}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4695811912248111435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4583912175739985978}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.136, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4718801931691354986}
+  - {fileID: 7446305213577957298}
+  - {fileID: 2691868551401171317}
+  - {fileID: 2628702113225851363}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4711842618106318881
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6344457760561288262}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.10045143, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 183903037133630456}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4718801931691354986
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.809, z: 0.052}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4695811912248111435}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5141076249776533607
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2686152598055294379}
+  m_Layer: 6
+  m_Name: Leg.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5943071206077373607
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3913231710814042125}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.064354844, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2257292714694726912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &6224648825763604526
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454343646476026035}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.026484087, y: -0.17570221, z: 0.9825096, w: -0.05569769}
+  m_LocalPosition: {x: 0.06717399, y: -0.014853266, z: 0.018340638}
+  m_LocalScale: {x: 1.0000014, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2686152598055294379}
+  m_Father: {fileID: 4658574641059729974}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6344457760561288262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4711842618106318881}
+  m_Layer: 6
+  m_Name: Foot.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6534746945289868042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 11025683570335562}
+  m_Layer: 6
+  m_Name: UpArm.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6597801881702472895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4718801931691354986}
+  - component: {fileID: 8291068422825249420}
+  - component: {fileID: 8948636055162779067}
+  - component: {fileID: 3352834383585050582}
+  - component: {fileID: 3747044170552412223}
+  - component: {fileID: 4308960723045311337}
+  - component: {fileID: 4180355613093911740}
+  m_Layer: 2
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6647807635380555708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 888086788494253768}
+  m_Layer: 6
+  m_Name: UpArm.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &6947911646296722071
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4583912175739985978}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.5, z: 0}
+--- !u!4 &7045224929859355427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7174686271617268493}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.20820376, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8949230271590860975}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7071376487801060839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8607218787004243043}
+  m_Layer: 6
+  m_Name: Chest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7140482572591265090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2691868551401171317}
+  - component: {fileID: 8693475851828370930}
+  m_Layer: 2
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7174686271617268493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7045224929859355427}
+  m_Layer: 6
+  m_Name: Arm.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7188367493144839497
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872827410078174523}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.07091896, y: 1.507484e-14, z: -0.000000016909254, w: 0.9974821}
+  m_LocalPosition: {x: 2.9976022e-15, y: 0.10205682, z: -0.000000001396981}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2297077368054180529}
+  m_Father: {fileID: 1333413327091532229}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &7271733266709545568
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8469293050937787533}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.9104015, y: -0.038027506, z: 0.032824345, w: 0.4106648}
+  m_LocalPosition: {x: 0.0000000057043508, y: 0.15473321, z: -0.000000019557774}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7750743801554318727}
+  m_Father: {fileID: 2686152598055294379}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7298359342184009883
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2297077368054180529}
+  m_Layer: 6
+  m_Name: Tail.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7373201546310917934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2170160289069579735}
+  m_Layer: 6
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7446305213577957298
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7618034750904610352}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: 0.0000000121071935, y: 0, z: -0.000000014901161}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4658574641059729974}
+  m_Father: {fileID: 4695811912248111435}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7502544797650771925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8949230271590860975}
+  m_Layer: 6
+  m_Name: Arm.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7618034750904610352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7446305213577957298}
+  m_Layer: 6
+  m_Name: Armature
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7676194569590082496
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7750743801554318727}
+  m_Layer: 6
+  m_Name: Foot.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7750743801554318727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7676194569590082496}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.10045143, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7271733266709545568}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7782227643932880025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8289972788491150895}
+  m_Layer: 6
+  m_Name: UpLeg.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &8024219688827246704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4553582587284138215}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a33e5eef0a8c6244797f2e26a51b7533, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8145962093308262437
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4583912175739985978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 707f07e2baeb22443b8730242e95cb4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerSpeed: 5
+  runSPEED: 2
+  x_sensi: 1000
+  y_sensi: 1000
+  Maincamera: {fileID: 6597801881702472895}
+  anim: {fileID: 8910344399797964928}
+  jumpPower: 5
+--- !u!4 &8203618216221069278
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3255972873161196318}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.08510685, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2297077368054180529}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &8289972788491150895
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7782227643932880025}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.061812572, y: 0.20424923, z: 0.9756972, w: 0.049763307}
+  m_LocalPosition: {x: -0.06717397, y: -0.014853266, z: 0.018340671}
+  m_LocalScale: {x: 1.000002, y: 1.0000002, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4307990368051959257}
+  m_Father: {fileID: 4658574641059729974}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &8291068422825249420
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!1 &8401638981111238710
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4307990368051959257}
+  m_Layer: 6
+  m_Name: Leg.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &8445350416798803489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8814924875373889612}
+  m_Layer: 6
+  m_Name: Arm.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &8469293050937787533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7271733266709545568}
+  m_Layer: 6
+  m_Name: Foot.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8607218787004243043
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7071376487801060839}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.10969388, y: 0.00000011848991, z: -0.0000000130765265, w: 0.99396545}
+  m_LocalPosition: {x: -8.881784e-16, y: 0.19863403, z: -0.0000000037252874}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2170160289069579735}
+  - {fileID: 888086788494253768}
+  - {fileID: 11025683570335562}
+  m_Father: {fileID: 4658574641059729974}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8687233939688078801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1333413327091532229}
+  m_Layer: 6
+  m_Name: Tail.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!137 &8693475851828370930
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7140482572591265090}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 5819227119962715586, guid: 6a901c31893028b4e9cacb31edde81e0, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -5495902117074765545, guid: 6a901c31893028b4e9cacb31edde81e0, type: 3}
+  m_Bones:
+  - {fileID: 4658574641059729974}
+  - {fileID: 8607218787004243043}
+  - {fileID: 2170160289069579735}
+  - {fileID: 2257292714694726912}
+  - {fileID: 888086788494253768}
+  - {fileID: 8949230271590860975}
+  - {fileID: 11025683570335562}
+  - {fileID: 8814924875373889612}
+  - {fileID: 8289972788491150895}
+  - {fileID: 4307990368051959257}
+  - {fileID: 183903037133630456}
+  - {fileID: 6224648825763604526}
+  - {fileID: 2686152598055294379}
+  - {fileID: 7271733266709545568}
+  - {fileID: 1333413327091532229}
+  - {fileID: 7188367493144839497}
+  - {fileID: 2297077368054180529}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 4658574641059729974}
+  m_AABB:
+    m_Center: {x: 0.000000014901161, y: 0.2350263, z: 0.0041179955}
+    m_Extent: {x: 0.3784033, y: 0.5582249, z: 0.34902558}
+  m_DirtyAABB: 0
+--- !u!4 &8814924875373889612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8445350416798803489}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.67366886, y: 0.25529504, z: 0.003721257, w: 0.6935279}
+  m_LocalPosition: {x: -0.000000026077032, y: 0.1165086, z: -0.000000044965418}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2789014193716960744}
+  m_Father: {fileID: 11025683570335562}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &8910344399797964928
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4583912175739985978}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 76dd9120f4878344495549036e57d59b, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 1
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!81 &8948636055162779067
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6597801881702472895}
+  m_Enabled: 1
+--- !u!4 &8949230271590860975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7502544797650771925}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.62353253, y: 0.26642388, z: -0.0188564, w: 0.7347585}
+  m_LocalPosition: {x: 0.000000011175871, y: 0.11650859, z: 0.000000041734893}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7045224929859355427}
+  m_Father: {fileID: 888086788494253768}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9081052709994507566 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5111317904337636692, guid: 816680e38a2df2e4198dabed748810e9, type: 3}
@@ -1281,8 +2628,12 @@ SceneRoots:
   - {fileID: 756423102}
   - {fileID: 442194812}
   - {fileID: 357116266}
+  - {fileID: 4695811912248111435}
   - {fileID: 642388886}
   - {fileID: 2089380216}
-  - {fileID: 8233579744030125589}
-  - {fileID: 1032532471685915511}
-  - {fileID: 5429571905572514160}
+  - {fileID: 697742538}
+  - {fileID: 570380595}
+  - {fileID: 1279545926}
+  - {fileID: 1816622134}
+  - {fileID: 400864848}
+  - {fileID: 1846178143}

--- a/Assets/Aoyama/Scripts/Buff_debuff_manager.cs
+++ b/Assets/Aoyama/Scripts/Buff_debuff_manager.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Buff_debuff_manager : MonoBehaviour
+{
+    [Header("PlayerのPlayerController script")] public PlayerController playerCon;
+
+    [Header("Playerアイテム獲得時、止まる時間（デバフ）")] public float stopTime = 2f;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    //Playerを一定時間停止させるコルーチン開始
+    public void PlayerStop()
+    {
+        StartCoroutine(StopTimer());
+    }
+
+    //Playerを一定時間停止させる
+    private IEnumerator StopTimer()
+    {
+        var speed = playerCon.PlayerSpeed; //元のPlayerSpeedを記録
+        playerCon.PlayerSpeed = 0; //PlayerSpeedを0に
+
+        yield return new WaitForSeconds(stopTime); //～秒間停止
+
+        //Debug.Log("飽きた");
+        playerCon.PlayerSpeed = speed; //speedをもとに戻す
+    }
+}

--- a/Assets/Aoyama/Scripts/Buff_debuff_manager.cs.meta
+++ b/Assets/Aoyama/Scripts/Buff_debuff_manager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed120779cee8a234f959198719c7a85b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aoyama/Scripts/Nekozyarashi.meta
+++ b/Assets/Aoyama/Scripts/Nekozyarashi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88a7d1615594a6c469f196bb7cc77e59
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aoyama/Scripts/Nekozyarashi/Nekozyarashi.cs
+++ b/Assets/Aoyama/Scripts/Nekozyarashi/Nekozyarashi.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Nekozyarashi : MonoBehaviour
+{
+    [Header("BuffDebuffManagerのBuff__debuff_manager script")]public Buff_debuff_manager buff_debuff;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    //Playerが獲得すると少しの間止まる
+    private void OnDestroy()
+    {
+        //Debug.Log("猫じゃらしに夢中！")
+
+        buff_debuff.PlayerStop(); //Playerを一定時間停止させるデバフの関数を呼び出す
+    }
+}

--- a/Assets/Aoyama/Scripts/Nekozyarashi/Nekozyarashi.cs.meta
+++ b/Assets/Aoyama/Scripts/Nekozyarashi/Nekozyarashi.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d5915b8101ecf848bc92bd4668cbc9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aoyama/Scripts/Nezumi/Enemy_view.cs
+++ b/Assets/Aoyama/Scripts/Nezumi/Enemy_view.cs
@@ -60,7 +60,9 @@ public class Enemy_view : MonoBehaviour
             //Rayが最初に当たった物体を調べる
             if (Physics.Raycast(ray.origin, ray.direction * distance_red, out hit))
             {
-                if (hit.collider.CompareTag("Player"))
+                //Debug.Log(hit.collider.tag);
+
+                if (hit.collider.CompareTag("Player") || hit.collider.CompareTag("GetItemArea")) //GetItemAreaが最初にRayに当たるはず
                 {
                     if (discovered == false)
                     {

--- a/Assets/Aoyama/Scripts/Nezumi/NezumiController.cs
+++ b/Assets/Aoyama/Scripts/Nezumi/NezumiController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class NezumiController : MonoBehaviour
 {
-    [Header("プレイヤーのゲームオブジェクト")]public GameObject player;
+    [Header("プレイヤーのゲームオブジェクト")] [SerializeField] GameObject player;
     [Header("移動速度(0.02~0.1 プレイヤーより遅めに)")]public float speed = 0.04f;   
     [Header("「移動 → 止まる」ループの移動する時間")]public float moveTime = 2.0f; //～秒動いて、
     [Header("「移動 → 止まる」ループの止まる時間")]public float stopTime = 1.0f; //～秒止まる

--- a/Assets/Aoyama/Scripts/Sakana.meta
+++ b/Assets/Aoyama/Scripts/Sakana.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aae814d5f0b8bb74bbe70e397e74d0da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aoyama/Scripts/Sakana/SakanaConttroller.cs
+++ b/Assets/Aoyama/Scripts/Sakana/SakanaConttroller.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SakanaConttroller : MonoBehaviour
+{
+    [Header("PlayerのHP管理のscript")] [SerializeField] HP3manager HP3manager;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnDestroy()
+    {
+        HP3manager.IncreaseHp();
+    }
+}

--- a/Assets/Aoyama/Scripts/Sakana/SakanaConttroller.cs.meta
+++ b/Assets/Aoyama/Scripts/Sakana/SakanaConttroller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebdbfc2d4fb531047847f67fd88f4523
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,7 +8,8 @@ TagManager:
   - Enemy
   - Eye
   - Wall
-  - Item
+  - item
+  - GetItemArea
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
魚はHPが1回復、猫じゃらしは一定時間その場を動けないようにする効果を実装しました。
アイテム獲得後（オブジェクトが消えた後）も一定時間バフデバフの効果がある場合はバフデバフマネージャーに実装しています。